### PR TITLE
Allow user-specified Model base classes

### DIFF
--- a/flaskext/sqlalchemy.py
+++ b/flaskext/sqlalchemy.py
@@ -564,6 +564,25 @@ class SQLAlchemy(object):
        emulates `Table` behavior but is not a class. `db.Table` exposes the
        `Table` interface, but is a function which allows omission of metadata.
 
+    To use a different base class for your models, create a subclass of
+    :class:`Model` and provide it as the `modelclass` keyword argument to this
+    function::
+
+        from flaskext.sqlalchemy import Model
+
+        class MyBaseModel(Model):
+            def print_hello(self):
+                print 'Hello'
+
+        app = Flask(__name__)
+        db = SQLAlchemy(app)
+
+        class User(db.Model):
+            name = db.Column(db.String(80))
+
+        user = User(name='John')
+        user.print_hello() # prints 'Hello'
+
     You may also define your own SessionExtension instances as well when
     defining your SQLAlchemy class instance. You may pass your custom instances
     to the `session_extensions` keyword. This can be either a single
@@ -591,10 +610,16 @@ class SQLAlchemy(object):
     .. versionadded:: 0.16
        `scopefunc` is now accepted on `session_options`. It allows specifying
         a custom function which will define the SQLAlchemy session's scoping.
+
+    .. versionadded:: 0.16
+       `modelclass` is used as the base class for the declarative base, to
+       allow for user-specified base classes.
+
     """
 
     def __init__(self, app=None, use_native_unicode=True,
-                 session_extensions=None, session_options=None):
+                 session_extensions=None, session_options=None,
+                 modelclass=Model):
         self.use_native_unicode = use_native_unicode
         self.session_extensions = to_list(session_extensions, []) + \
                                   [_SignallingSessionExtension()]
@@ -607,7 +632,7 @@ class SQLAlchemy(object):
         )
 
         self.session = self.create_scoped_session(session_options)
-        self.Model = self.make_declarative_base()
+        self.Model = self.make_declarative_base(modelclass)
         self._engine_lock = Lock()
 
         if app is not None:
@@ -633,9 +658,15 @@ class SQLAlchemy(object):
             partial(_SignallingSession, self, **options), scopefunc=scopefunc
         )
 
-    def make_declarative_base(self):
-        """Creates the declarative base."""
-        base = declarative_base(cls=Model, name='Model',
+    def make_declarative_base(self, modelclass=Model):
+        """Creates the declarative base.
+
+        .. versionadded:: 0.16
+           `modelclass` is used as the base class for the declarative base, to
+           allow for user-specified base classes.
+
+        """
+        base = declarative_base(cls=modelclass, name='Model',
                                 mapper=signalling_mapper,
                                 metaclass=_BoundDeclarativeMeta)
         base.query = _QueryProperty(self)


### PR DESCRIPTION
This is in response to issue #62. It allows a user to specify a base class for models (which should be a subclass of ``flaskext.sqlalchemy.Model``) in the constructor of ``flaskext.sqlalchemy.SQLALchemy``. **Note**: this does not work with the ``SQLAlchemy.init_app(app)`` idiom unless the model class is specified in the constructor of ``SQLAlchemy``.