### PR TITLE
Allow optional message on 404 from db query

### DIFF
--- a/flask_sqlalchemy.py
+++ b/flask_sqlalchemy.py
@@ -351,22 +351,22 @@ class BaseQuery(orm.Query):
     standard query as well.
     """
 
-    def get_or_404(self, ident):
+    def get_or_404(self, ident, description=None):
         """Like :meth:`get` but aborts with 404 if not found instead of
         returning `None`.
         """
         rv = self.get(ident)
         if rv is None:
-            abort(404)
+            abort(404, description=description)
         return rv
 
-    def first_or_404(self):
+    def first_or_404(self, description=None):
         """Like :meth:`first` but aborts with 404 if not found instead of
         returning `None`.
         """
         rv = self.first()
         if rv is None:
-            abort(404)
+            abort(404, description=description)
         return rv
 
     def paginate(self, page, per_page=20, error_out=True):


### PR DESCRIPTION
`description` arg on `.get_or_404()` and `.first_or_404()` is passed to abort, which in turn passes it to the NotFound exception.

For example, the following will return a 404 response with 'Unknown User' in it's body.

```python
User.query.get_or_404('Unknown user')
```