### PR TITLE
Fix before_models_committed signal

### DIFF
--- a/flask_sqlalchemy.py
+++ b/flask_sqlalchemy.py
@@ -174,9 +174,15 @@ class _SignalTrackingMapperExtension(MapperExtension):
 class _SignallingSessionExtension(SessionExtension):
 
     def before_commit(self, session):
-        d = session._model_changes
-        if d:
-            before_models_committed.send(session.app, changes=d.values())
+        if session._new or session._deleted or session.identity_map:
+            s = []
+            for new in session._new:
+                s.append((new.obj(), 'insert'))
+            for delete in session._deleted:
+                s.append((delete.obj(), 'delete'))
+            for mod in session.identity_map._modified:
+                s.append((mod.obj(), 'update'))
+            before_models_committed.send(session.app, changes=s)
         return EXT_CONTINUE
 
     def after_commit(self, session):

--- a/test_sqlalchemy.py
+++ b/test_sqlalchemy.py
@@ -155,6 +155,41 @@ class SignallingTestCase(unittest.TestCase):
             self.assertEqual(recorded[0][0], todo)
             self.assertEqual(recorded[0][1], 'delete')
 
+    def test_before_committed(self):
+        recorded = []
+        called = []
+        def committed(sender, changes):
+            called.append(1)
+            if changes[0][1] != 'delete':
+                self.assertFalse('text' in changes[0][0]._sa_instance_state.unmodified)
+            self.assert_(isinstance(changes, list))
+            recorded.extend(changes)
+        with sqlalchemy.before_models_committed.connected_to(committed,
+                                                      sender=self.app):
+            todo = self.Todo('Awesome', 'the text')
+            self.db.session.add(todo)
+            self.db.session.commit()
+            self.assertTrue(called, 'Before commit not called')
+            del called[:]
+            self.assertEqual(len(recorded), 1)
+            self.assertEqual(recorded[0][0], todo)
+            self.assertEqual(recorded[0][1], 'insert')
+            del recorded[:]
+            todo.text = 'aha'
+            self.db.session.commit()
+            self.assertTrue(called, 'Before commit not called')
+            del called[:]
+            self.assertEqual(len(recorded), 1)
+            self.assertEqual(recorded[0][0], todo)
+            self.assertEqual(recorded[0][1], 'update')
+            del recorded[:]
+            self.db.session.delete(todo)
+            self.db.session.commit()
+            self.assertTrue(called, 'Before commit not called')
+            self.assertEqual(len(recorded), 1)
+            self.assertEqual(recorded[0][0], todo)
+            self.assertEqual(recorded[0][1], 'delete')
+
 
 class HelperTestCase(unittest.TestCase):
 


### PR DESCRIPTION
As per #90 - I'm seeing the same thing; the signal never fires because `d` is always empty when it does. I originally added `before_{insert,update,delete}` event handlers, but it looks like `before_commit` fires before even they do.

The approach on this pull request is to introspect the session object and see what is queued to be committed. I've included tests done by @DazWorrall which originally failed but now pass and I believe cover what the documentation says this signal should do.