### PR TITLE
Support for before_models_flushed and models_flushed signals

### DIFF
--- a/flask_sqlalchemy.py
+++ b/flask_sqlalchemy.py
@@ -169,7 +169,7 @@ class _SignalTrackingMapperExtension(MapperExtension):
         s = orm.object_session(model)
         # Skip the operation tracking when a non signalling session
         # is used.
-        if isinstance(s, _SignallingSessionExtension):
+        if isinstance(s, _SignallingSession):
             pk = tuple(mapper.primary_key_from_instance(model))
             s._model_changes[pk] = (model, operation)
         return EXT_CONTINUE


### PR DESCRIPTION
The first commit includes a fix for breakage of sqlalchemy hooks done by mistake in mitsuhiko/flask-sqlalchemy@cf40caec1c48fc2188597ca4e6ddfb21b770d9d7

The second commit introduces support for before_models_flushed and models_flushed signals, closing mitsuhiko/flask-sqlalchemy#9