### PR TITLE
added ability to do runtime configuration of database schema

### DIFF
--- a/test_sqlalchemy.py
+++ b/test_sqlalchemy.py
@@ -488,6 +488,29 @@ class StandardSessionTestCase(unittest.TestCase):
         session.delete(qaz_wsx) # issues a DELETE.
         assert session.query(QazWsx).first() is None
 
+class SetSchemaTestCase(unittest.TestCase):
+
+    def test_insert_update_delete(self):
+        # Ensure _SignalTrackingMapperExtension doesn't croak when
+        # faced with a vanilla SQLAlchemy session.
+        #
+        # Verifies that "AttributeError: 'SessionMaker' object has no attribute '_model_changes'"
+        # is not thrown.
+        app = flask.Flask(__name__)
+        app.config['SQLALCHEMY_ENGINE'] = 'sqlite://'
+        app.config['TESTING'] = True
+        test_schema = 'naboo'
+        db = sqlalchemy.SQLAlchemy(app, schema=test_schema)
+        Session = sessionmaker(bind=db.engine)
+
+        class QazWsx(db.Model):
+            id = db.Column(db.Integer, primary_key=True)
+            x = db.Column(db.String, default='')
+
+        a = QazWsx()
+
+        assert a.metadata.schema != 'alderan'
+        assert a.metadata.schema == test_schema
 
 def suite():
     suite = unittest.TestSuite()
@@ -501,6 +524,7 @@ def suite():
     suite.addTest(unittest.makeSuite(RegressionTestCase))
     suite.addTest(unittest.makeSuite(SessionScopingTestCase))
     suite.addTest(unittest.makeSuite(CommitOnTeardownTestCase))
+    suite.addTest(unittest.makeSuite(SetSchemaTestCase))
     if flask.signals_available:
         suite.addTest(unittest.makeSuite(SignallingTestCase))
     suite.addTest(unittest.makeSuite(StandardSessionTestCase))


### PR DESCRIPTION
Preface -> not sure I know what I am doing as I am new to sqlalchemy and flask.

As far as I have been able to understand from the docs and playing around with everything is there is no way to do runtime configuration of the schema. There is a lot to understand here so my apologies if this is already possible via other means.

My specific use case is that I want to have the same set of table's in multiple schemas inside the postgres database. 

Example: client1.users and client2.users

This is easy to do in SQLAlchemy but I couldn't figure out a way to make the flask sqlalchemy extension perform this. My goal with my hack was to enable this extension to do runtime configuration. 

This appears to already be possible in mysql as the URI configuration seems to allow you to specify a schema but I could find no corollary for postgres.

My apologies for any bad code. Just wanted to get the idea out there.