### PR TITLE
Signal won't be fired on operating multiple models having same PK

### DIFF
--- a/flask_sqlalchemy/__init__.py
+++ b/flask_sqlalchemy/__init__.py
@@ -196,7 +196,7 @@ class _MapperSignalEvents(object):
 
     @staticmethod
     def _record(mapper, target, operation):
-        pk = tuple(mapper.primary_key_from_instance(target))
+        pk = tuple([target.__tablename__] + mapper.primary_key_from_instance(target))
         orm.object_session(target)._model_changes[pk] = (target, operation)
 
 


### PR DESCRIPTION
When insert or update multiple tables in one transaction, only one signal will be fired if those tables has same primary key.
To solve this problem, I added the tablename to _model_changes key.