### PR TITLE
Fix a bug where options were not passed correctly to the create_session ...

### DIFF
--- a/flask_sqlalchemy/__init__.py
+++ b/flask_sqlalchemy/__init__.py
@@ -692,10 +692,10 @@ class SQLAlchemy(object):
         if options is None:
             options = {}
         scopefunc = options.pop('scopefunc', None)
-        return orm.scoped_session(partial(self.create_session, options),
+        return orm.scoped_session(partial(self.create_session, **options),
                                   scopefunc=scopefunc)
 
-    def create_session(self, options):
+    def create_session(self, **options):
         """Creates the session.  The default implementation returns a
         :class:`SignallingSession`.
 


### PR DESCRIPTION
The way it's written does not allow to pass parameters for a ad-hoc session which is different from the global configuration and will fail when SQLAlchemy will try to call the create_session function.
For example, this will not work without the fix:
```python
app = Flask(__name__)
db = SQLAlchemy(app)
with app.app_context():
    s = db.session(expire_on_commit=False)
    s.add(SomeModel)
    s.commit()
```