### PR TITLE
Convert to relative imports

### DIFF
--- a/flask_sqlalchemy/__init__.py
+++ b/flask_sqlalchemy/__init__.py
@@ -27,8 +27,7 @@ from sqlalchemy.orm.session import Session as SessionBase
 from sqlalchemy.event import listen
 from sqlalchemy.engine.url import make_url
 from sqlalchemy.ext.declarative import declarative_base, DeclarativeMeta
-from flask.ext.sqlalchemy._compat import iteritems, itervalues, xrange, \
-     string_types
+from ._compat import iteritems, itervalues, xrange, string_types
 
 # the best timer function for the platform
 if sys.platform == 'win32':


### PR DESCRIPTION
Using "flask.ext.sqlalchemy" within the import creates problems for programs like pyinstaller, py2app, py2exe, or cx-freeze.

These programs freeze the executables and linked python packages in a codebase by recursively checking import statements throughout all dependencies.

Since flask uses redirection from flask.ext.sqlalchmey to flask_sqlalchemy, the import statements are not understood unless one explicitly adds a "hidden_import" of flask_sqlalchemy.

Upon adding this hidden_import, the code works fine, only if relative imports are used within the codebase.

Otherwise, individual hidden_imports must be added for each import, like flask.ext.sqlalchmey._compat.