### PR TITLE
Scoped Session returns instance object

### DIFF
--- a/flask_sqlalchemy/__init__.py
+++ b/flask_sqlalchemy/__init__.py
@@ -169,6 +169,10 @@ class SignallingSession(SessionBase):
                 return state.db.get_engine(self.app, bind=bind_key)
         return SessionBase.get_bind(self, mapper, clause)
 
+    def add(self, instance, **kw):
+        SessionBase.add(self, instance, **kw)
+        return instance
+
 
 class _SessionSignalEvents(object):
 


### PR DESCRIPTION
This updates the SQLAlchemy object so that the sessions it generates, when used to add an object
to the database, returns an instance of the object added.

Use case:
t = db.session.query(Topbooks).filter('user'==current_user).first() or db.session.add(Topbooks(user=current_user))
