### PR TITLE
Allow passing of base_metaclass to SQLAlchemy class

### DIFF
--- a/flask_sqlalchemy/__init__.py
+++ b/flask_sqlalchemy/__init__.py
@@ -510,7 +510,7 @@ def _defines_primary_key(d):
                if isinstance(v, sqlalchemy.Column))
 
 
-class _BoundDeclarativeMeta(DeclarativeMeta):
+class BoundDeclarativeMeta(DeclarativeMeta):
 
     def __new__(cls, name, bases, d):
         tablename = d.get('__tablename__')
@@ -655,7 +655,8 @@ class SQLAlchemy(object):
 
     def __init__(self, app=None,
                  use_native_unicode=True,
-                 session_options=None):
+                 session_options=None,
+                 base_metaclass=BoundDeclarativeMeta):
         self.use_native_unicode = use_native_unicode
 
         if session_options is None:
@@ -666,7 +667,7 @@ class SQLAlchemy(object):
         )
 
         self.session = self.create_scoped_session(session_options)
-        self.Model = self.make_declarative_base()
+        self.Model = self.make_declarative_base(base_metaclass)
         self._engine_lock = Lock()
 
         if app is not None:
@@ -703,10 +704,10 @@ class SQLAlchemy(object):
         """
         return SignallingSession(self, **options)
 
-    def make_declarative_base(self):
+    def make_declarative_base(self, base_metaclass):
         """Creates the declarative base."""
         base = declarative_base(cls=Model, name='Model',
-                                metaclass=_BoundDeclarativeMeta)
+                                metaclass=base_metaclass)
         base.query = _QueryProperty(self)
         return base
 


### PR DESCRIPTION
Small change to allow passing of a custom metaclass through to the base class creation.