### PR TITLE
Better sessions

### DIFF
--- a/flask_sqlalchemy/__init__.py
+++ b/flask_sqlalchemy/__init__.py
@@ -144,20 +144,20 @@ class SignallingSession(SessionBase):
     .. versionadded:: 2.0
     """
 
-    def __init__(self, db, autocommit=False, autoflush=True, **options):
+    def __init__(self, db, autocommit=False, autoflush=True, app=None, **options):
         #: The application that this session belongs to.
-        self.app = db.get_app()
+        self.app = app = app or db.get_app()
         self._model_changes = {}
         #: A flag that controls whether this session should keep track of
         #: model modifications.  The default value for this attribute
         #: is set from the ``SQLALCHEMY_TRACK_MODIFICATIONS`` config
         #: key.
         self.emit_modification_signals = \
-            self.app.config['SQLALCHEMY_TRACK_MODIFICATIONS']
+            app.config['SQLALCHEMY_TRACK_MODIFICATIONS']
         bind = options.pop('bind', None) or db.engine
+        binds = options.pop('binds', db.get_binds(app))
         SessionBase.__init__(self, autocommit=autocommit, autoflush=autoflush,
-                             bind=bind,
-                             binds=db.get_binds(self.app), **options)
+                             bind=bind, binds=binds, **options)
 
     def get_bind(self, mapper, clause=None):
         # mapper is None if someone tries to just get a connection


### PR DESCRIPTION
Given this change one can now use the technique as describe by the SQLAlchemy docs regarding [joining a session into an external transaction](http://docs.sqlalchemy.org/en/latest/orm/session_transaction.html#joining-a-session-into-an-external-transaction-such-as-for-test-suites). For example, and bearing in mind I also have `SQLALCHEMY_COMMIT_ON_TEARDOWN = True` as a default setting on my app, I can now rollback everything as one transaction:

```python
import pytest

def pytest_runtest_call(item):
    # Flush all fixtures before the test is called
    if hasattr(item, 'funcargs') and 'db_session' in item.funcargs:
        item.funcargs.get('db_session').flush()

@pytest.yield_fixture()
def db_session(app, db):
    with app.app_context():
        connection = db.engine.connect()
        transaction = connection.begin()
        options = dict(bind=connection, binds={})
        session = db.create_scoped_session(options=options)
        db.session = session
        yield session
        transaction.rollback()
        connection.close()
        session.remove()

@pytest.fixture()
def user(db_session):
    user = MyUserClass(...)
    db.session.add(user)
```

This would take care of #243.