### PR TITLE
document automatic tablename

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -27,6 +27,13 @@ Models
       Optionally declares the bind to use.  `None` refers to the default
       bind.  For more information see :ref:`binds`.
 
+   .. attribute:: __tablename__
+
+      The name of the table in the database.  This is required by SQLAlchemy;
+      however, Flask-SQLAlchemy will set it automatically if a model has a
+      primary key defined.  If the ``__table__`` or ``__tablename__`` is set
+      explicitly, that will be used instead.
+
 .. autoclass:: BaseQuery
    :members: get, get_or_404, paginate, first_or_404
 
@@ -54,7 +61,7 @@ Models
       Return the first result of this query or `None` if the result
       doesn’t contain any rows.  This results in an execution of the
       underlying query.
-    
+
 Sessions
 ````````
 


### PR DESCRIPTION
Mention that a tablename will be generated if the model sets a primary key and doesn't otherwise set a tablename.  Related to #248.  Addresses #213.