### PR TITLE
Change import to reflect deprecated ext format

### DIFF
--- a/docs/contexts.rst
+++ b/docs/contexts.rst
@@ -16,7 +16,7 @@ object globally, how does the latter learn about the former?  The answer
 is the :meth:`~SQLAlchemy.init_app` function::
 
     from flask import Flask
-    from flask.ext.sqlalchemy import SQLAlchemy
+    from flask_sqlalchemy import SQLAlchemy
 
     db = SQLAlchemy()
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -22,7 +22,7 @@ provides a class called `Model` that is a declarative base which can be
 used to declare models::
 
     from flask import Flask
-    from flask.ext.sqlalchemy import SQLAlchemy
+    from flask_sqlalchemy import SQLAlchemy
 
     app = Flask(__name__)
     app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:////tmp/test.db'

--- a/flask_sqlalchemy/__init__.py
+++ b/flask_sqlalchemy/__init__.py
@@ -27,7 +27,7 @@ from sqlalchemy.orm.exc import UnmappedClassError
 from sqlalchemy.orm.session import Session as SessionBase
 from sqlalchemy.engine.url import make_url
 from sqlalchemy.ext.declarative import declarative_base, DeclarativeMeta
-from flask.ext.sqlalchemy._compat import iteritems, itervalues, xrange, \
+from flask_sqlalchemy._compat import iteritems, itervalues, xrange, \
      string_types
 
 # the best timer function for the platform

--- a/test_sqlalchemy.py
+++ b/test_sqlalchemy.py
@@ -405,7 +405,7 @@ class SQLAlchemyIncludesTestCase(unittest.TestCase):
         self.assertTrue(db.Column == sqlalchemy_lib.Column)
 
         # The Query object we expose is actually our own subclass.
-        from flask.ext.sqlalchemy import BaseQuery
+        from flask_sqlalchemy import BaseQuery
         self.assertTrue(db.Query == BaseQuery)
 
 


### PR DESCRIPTION
See: https://github.com/mitsuhiko/flask/issues/1135

Not sure if we can/need to also change this in the documentation generation.