### PR TITLE
Change import to reflect deprecated ext format

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,7 +1,7 @@
 API
 ---
 
-.. module:: flask.ext.sqlalchemy
+.. module:: flask_sqlalchemy
 
 This part of the documentation documents all the public classes and
 functions in Flask-SQLAlchemy.

--- a/docs/binds.rst
+++ b/docs/binds.rst
@@ -1,6 +1,6 @@
 .. _binds:
 
-.. currentmodule:: flask.ext.sqlalchemy
+.. currentmodule:: flask_sqlalchemy
 
 Multiple Databases with Binds
 =============================

--- a/docs/contexts.rst
+++ b/docs/contexts.rst
@@ -1,6 +1,6 @@
 .. _contexts:
 
-.. currentmodule:: flask.ext.sqlalchemy
+.. currentmodule:: flask_sqlalchemy
 
 Introduction into Contexts
 ==========================

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,7 +3,7 @@
 Flask-SQLAlchemy
 ================
 
-.. module:: flask.ext.sqlalchemy
+.. module:: flask_sqlalchemy
 
 Flask-SQLAlchemy is an extension for `Flask`_ that adds support for
 `SQLAlchemy`_ to your application.  It requires SQLAlchemy 0.6 or

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -1,6 +1,6 @@
 .. _models:
 
-.. currentmodule:: flask.ext.sqlalchemy
+.. currentmodule:: flask_sqlalchemy
 
 Declaring Models
 ================

--- a/docs/queries.rst
+++ b/docs/queries.rst
@@ -1,4 +1,4 @@
-.. currentmodule:: flask.ext.sqlalchemy
+.. currentmodule:: flask_sqlalchemy
 
 Select, Insert, Delete
 ======================

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -3,7 +3,7 @@
 Quickstart
 ==========
 
-.. currentmodule:: flask.ext.sqlalchemy
+.. currentmodule:: flask_sqlalchemy
 
 Flask-SQLAlchemy is fun to use, incredibly easy for basic applications, and
 readily extends for larger applications.  For the complete guide, checkout


### PR DESCRIPTION
Use flask_sqlalchemy instead of flask.ext.sqlalchemy on module name. https://github.com/mitsuhiko/flask-sqlalchemy/pull/270

https://github.com/mitsuhiko/flask/issues/1135