### PR TITLE
Change docs/_themes submodule protocol from git:// to https://

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "docs/_themes"]
 	path = docs/_themes
-	url = git://github.com/mitsuhiko/flask-sphinx-themes.git
+	url = https://github.com/mitsuhiko/flask-sphinx-themes.git


### PR DESCRIPTION
Allows pip install from the git repository when the `git://` protocol is blocked.

In may environments, the `git://` protocol is blocked by the firewall. This causes

    pip install -e git+https://github.com/mitsuhiko/flask-sqlalchemy.git#egg=Flask-SQLAlchemy

to fail since it will hang on submodule initialization.