### PR TITLE
Avoid circular reference by deleting _SQLAlchemyState.app

### DIFF
--- a/flask_sqlalchemy/__init__.py
+++ b/flask_sqlalchemy/__init__.py
@@ -617,9 +617,8 @@ def get_state(app):
 class _SQLAlchemyState(object):
     """Remembers configuration for the (db, app) tuple."""
 
-    def __init__(self, db, app):
+    def __init__(self, db):
         self.db = db
-        self.app = app
         self.connectors = {}
 
 
@@ -796,7 +795,7 @@ class SQLAlchemy(object):
 
         if not hasattr(app, 'extensions'):
             app.extensions = {}
-        app.extensions['sqlalchemy'] = _SQLAlchemyState(self, app)
+        app.extensions['sqlalchemy'] = _SQLAlchemyState(self)
 
         # 0.9 and later
         if hasattr(app, 'teardown_appcontext'):


### PR DESCRIPTION
Since this attribute is not used anywhere in the implementation, we can
just delete it.

Otherwise, `app.extensions['sqlalchemy'].app` would be a circular
reference and cause memory leak.
