### PR TITLE
Fixed the issue with pool_size with sqllite

### DIFF
--- a/flask_sqlalchemy/__init__.py
+++ b/flask_sqlalchemy/__init__.py
@@ -861,8 +861,8 @@ class SQLAlchemy(object):
             # which is fail.  Let the user know that
             if info.database in (None, '', ':memory:'):
                 detected_in_memory = True
-                from sqlalchemy.pool import StaticPool
-                options['poolclass'] = StaticPool
+                from sqlalchemy.pool import SingletonThreadPool
+                options['poolclass'] = SingletonThreadPool
                 if 'connect_args' not in options:
                     options['connect_args'] = {}
                 options['connect_args']['check_same_thread'] = False


### PR DESCRIPTION
We use sqllite for unit testing out code we observed the following error
with flask_sqlalchmey 2.1

TypeError: Invalid argument(s) 'pool_size' sent to create_engine(), using
configuration SQLiteDialect_pysqlite/StaticPool/Engine.  Please check that
the keyword arguments are appropriate for this combination of components.

After investigating a bit, I've discovered that we were using wrong pooling
mechanism for sqllite in-memory dbs (StaticPool). You can get more details
http://docs.sqlalchemy.org/en/latest/core/pooling.html

Basically, for sqllite there only 2 pooling mechanisms i.e.,
1. SingletonThreadPool (in memory)
2. NullPool (file based)

So I have switched pooling mechanism to use SingletonThreadPool instead of
StaticPool to fix the issue.