### PR TITLE
Use Travis' container-based infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: python
 
+sudo: false
+
 python:
   - "2.6"
   - "2.7"


### PR DESCRIPTION
This adds the `sudo: false` config to speed up CI testing on TravisCI's new infrastructure.