### PR TITLE
Fix self.app not being set on init_app

### DIFF
--- a/flask_sqlalchemy/__init__.py
+++ b/flask_sqlalchemy/__init__.py
@@ -799,6 +799,7 @@ class SQLAlchemy(object):
         of an application not initialized that way or connections will
         leak.
         """
+        self.app = app
         app.config.setdefault('SQLALCHEMY_DATABASE_URI', 'sqlite://')
         app.config.setdefault('SQLALCHEMY_BINDS', None)
         app.config.setdefault('SQLALCHEMY_NATIVE_UNICODE', None)


### PR DESCRIPTION
I create a SQLAlchemy instance and import it into my application's main file from my models file. I then call init_app and was getting errors when I tried to perform actions with this instance and realized SQLAlchemy.app was never set when calling init_app on it.