### PR TITLE
Fix wrong query usage in documentation

### DIFF
--- a/docs/queries.rst
+++ b/docs/queries.rst
@@ -97,7 +97,7 @@ Selecting a bunch of users by a more complex expression:
 
 Ordering users by something:
 
->>> User.query.order_by(User.username)
+>>> User.query.order_by(User.username).all()
 [<User u'admin'>, <User u'guest'>, <User u'peter'>]
 
 Limiting users:


### PR DESCRIPTION
missing `.all()` in ordered query usage