### PR TITLE
Support binds on abstract models

### DIFF
--- a/flask_sqlalchemy/__init__.py
+++ b/flask_sqlalchemy/__init__.py
@@ -599,9 +599,9 @@ class _BoundDeclarativeMeta(DeclarativeMeta):
         return DeclarativeMeta.__new__(cls, name, bases, d)
 
     def __init__(self, name, bases, d):
-        bind_key = d.pop('__bind_key__', None)
+        bind_key = d.pop('__bind_key__', None) or getattr(self, '__bind_key__', None)
         DeclarativeMeta.__init__(self, name, bases, d)
-        if bind_key is not None:
+        if bind_key is not None and hasattr(self, '__table__'):
             self.__table__.info['bind_key'] = bind_key
 
 


### PR DESCRIPTION
Flask-SQLAlchemy is currently unable to handle defining a `__bind_key__` attribute on an abstract model. This change fixes that, and it includes an automated test.