### PR TITLE
Clean up tests, more thorough version testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,15 @@ python:
   - "3.4"
   - "3.5"
 
+env:
+  - REQUIREMENTS=lowest
+  - REQUIREMENTS=current
+
 install:
   - pip install tox
 
 script:
-  - tox -e py
+  - tox -e py-$REQUIREMENTS
 
 notifications:
   email: false

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,16 @@
 [tox]
-envlist = py26, py27, pypy, py33, py34, py35
+envlist = {py26,py27,pypy,py33,py34,py35}-{lowest,current}
 
 [testenv]
-commands = python test_sqlalchemy.py
+commands = py.test {posargs}
 
 deps =
-    blinker
+    pytest
+
+    lowest: flask==0.10
+    lowest: sqlalchemy==0.8
+    lowest: blinker==1.0
+
+    current: flask
+    current: sqlalchemy
+    current: blinker


### PR DESCRIPTION
* `SQLALCHEMY_ENGINE` isn't a config key, so the default `sqlite://` was being used.
* `SQLALCHEMY_DATABASE_URI` defaults to `sqlite://` anyway, so just remove all these configs
* `CustomQueryClassTestCase` wasn't registered
* `CustomQueryClassTestCase.test_dont_override_model_default` wasn't testing the right thing, and was also failing
* `CustomModelClassTestCase` wasn't registered
* `import flask_sqlalchemy as sqlalchemy` is a confusing alias, used `fsa` instead
* added "lowest" and "current" tox envs for testing dependency versions
* Flask lowest tests against blinker==1.0, which doesn't have `connected_to`, replace with `connect` and `disconnect`