### PR TITLE
Move a source code comment to proper position

### DIFF
--- a/flask_sqlalchemy/__init__.py
+++ b/flask_sqlalchemy/__init__.py
@@ -864,8 +864,6 @@ class SQLAlchemy(object):
         elif info.drivername == 'sqlite':
             pool_size = options.get('pool_size')
             detected_in_memory = False
-            # we go to memory and the pool size was explicitly set to 0
-            # which is fail.  Let the user know that
             if info.database in (None, '', ':memory:'):
                 detected_in_memory = True
                 from sqlalchemy.pool import StaticPool
@@ -874,6 +872,8 @@ class SQLAlchemy(object):
                     options['connect_args'] = {}
                 options['connect_args']['check_same_thread'] = False
 
+                # we go to memory and the pool size was explicitly set
+                # to 0 which is fail.  Let the user know that
                 if pool_size == 0:
                     raise RuntimeError('SQLite in memory database with an '
                                        'empty queue not possible due to data '


### PR DESCRIPTION
With commit 9b5bd9427fb3562926b3f9d9f9401ea6159a1fb2 this comment became unclear since code was added below the comment which is actually unrelated to what the comment talks about.