### PR TITLE
Provide additional documentation for SQLALCHEMY_POOL_RECYCLE

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -48,3 +48,4 @@ Patches and Suggestions
 - Steven Harms
 - David Lord @davidism
 - Alec Nikolas Reiter @justanr
+- Nick Whyte @nickw444

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -47,7 +47,10 @@ A list of configuration keys currently understood by the extension:
                                    connections after 8 hours idle by
                                    default.  Note that Flask-SQLAlchemy
                                    automatically sets this to 2 hours if
-                                   MySQL is used.
+                                   MySQL is used. Some backends may use a 
+                                   different default timeout value. For more 
+                                   information about timeouts see 
+                                   :ref:`timeouts`.
 ``SQLALCHEMY_MAX_OVERFLOW``        Controls the number of connections that
                                    can be created after the pool reached
                                    its maximum size.  When those additional
@@ -144,3 +147,21 @@ example, as suggested by the SQLAlchemy docs::
 For more info about :class:`~sqlalchemy.schema.MetaData`,
 `check out the official docs on it
 <http://docs.sqlalchemy.org/en/latest/core/metadata.html>`_.
+
+.. _timeouts:
+
+Timeouts
+--------
+
+Certain database backends may impose different inactive connection timeouts, 
+which interferes with Flask-SQLAlchemy's connection pooling. 
+
+By default, MariaDB is configured to have a 600 second timeout. This often 
+surfaces hard to debug, production environment only exceptions like ``2013: Lost connection to MySQL server during query``.
+
+If you are using a backend (or a pre-configured database-as-a-service) with a 
+lower connection timeout, it is recommended that you set 
+`SQLALCHEMY_POOL_RECYCLE` to a value less than your backend's timeout.
+
+
+


### PR DESCRIPTION
From issue #401, adding additional documentation to help users configuring Flask-SQLAlchemy with a backends with a shorter idle connection timeout such as:
- MariaDB
- SAAS/IAAS provided databases that are pre-configured

I've included the error that generally indicates this is an issue `2013: Lost connection to MySQL server during query` so users googling the exception will have a better chance of finding appropriate documentation. 
