### PR TITLE
Have sqlite relative paths use the config's root

### DIFF
--- a/flask_sqlalchemy/__init__.py
+++ b/flask_sqlalchemy/__init__.py
@@ -887,7 +887,7 @@ class SQLAlchemy(object):
 
             # if it's not an in memory database we make the path absolute.
             if not detected_in_memory:
-                info.database = os.path.join(app.root_path, info.database)
+                info.database = os.path.join(app.config.root_path, info.database)
 
         unu = app.config['SQLALCHEMY_NATIVE_UNICODE']
         if unu is None:


### PR DESCRIPTION
This makes relative paths do the right thing when the application has
instance_relative_config set to True.
