### PR TITLE
Don't crash when inspecting unsafe properties

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -49,3 +49,4 @@ Patches and Suggestions
 - David Lord @davidism
 - Alec Nikolas Reiter @justanr
 - Nick Whyte @nickw444
+- Adam Niederer

--- a/flask_sqlalchemy/__init__.py
+++ b/flask_sqlalchemy/__init__.py
@@ -577,7 +577,7 @@ def _should_set_tablename(bases, d):
             return False
 
         for name in dir(base):
-            attr = getattr(base, name)
+            attr = getattr(base, name, None)
 
             if isinstance(attr, sqlalchemy.Column) and attr.primary_key:
                 return True


### PR DESCRIPTION
If a class property is programmatically computed, it could potentially
throw an exception when run in this context. In that case, just move
on to the next property instead of crashing the entire application.