### PR TITLE
Fix next_num and prev_num showing non existant page nums

### DIFF
--- a/flask_sqlalchemy/__init__.py
+++ b/flask_sqlalchemy/__init__.py
@@ -342,6 +342,8 @@ class Pagination(object):
     @property
     def prev_num(self):
         """Number of the previous page."""
+        if not self.has_prev:
+            return None
         return self.page - 1
 
     @property
@@ -363,6 +365,8 @@ class Pagination(object):
     @property
     def next_num(self):
         """Number of the next page"""
+        if not self.has_next:
+            return None
         return self.page + 1
 
     def iter_pages(self, left_edge=2, left_current=2,


### PR DESCRIPTION
next_num and prev_num simply increment or decrement the current page number. Obviously this leads to having invalid next and prev nums in the paginated object.

Using flask-restless, this error shows up in the api responses. This patch returns None if there is no next or previous, because this is the way flask-restless does it as well.