### PR TITLE
Add Windows example for sqlite URI configuration.

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -115,10 +115,11 @@ SQLite (note that platform path conventions apply)::
 
     #Unix/Mac (note the four leading slashes)
     sqlite:////absolute/path/to/foo.db
-    #Windows using backslash escape
+    #Windows (note 3 leading forward slashes and backslash escapes)
     sqlite:///C:\\absolute\\path\\to\\foo.db
-    #Windows alternative using raw string
+    #Windows (alternative using raw string)
     r'sqlite:///C:\absolute\path\to\foo.db'
+
 Using custom MetaData and naming conventions
 --------------------------------------------
 

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -111,10 +111,14 @@ Oracle::
 
     oracle://scott:tiger@127.0.0.1:1521/sidname
 
-SQLite (note the four leading slashes)::
+SQLite (note that platform path conventions apply)::
 
+    #Unix/Mac (note the four leading slashes)
     sqlite:////absolute/path/to/foo.db
-
+    #Windows using backslash escape
+    sqlite:///C:\\absolute\\path\\to\\foo.db
+    #Windows alternative using raw string
+    r'sqlite:///C:\absolute\path\to\foo.db'
 Using custom MetaData and naming conventions
 --------------------------------------------
 


### PR DESCRIPTION
Addresses #469 -- adding windows example for URI configuration.

The current docs say
```
SQLite (note the four leading slashes):
    sqlite:////absolute/path/to/foo.db
```
However, this can lead to unexpected results on Windows. This PR modifies the notes and adds windows examples with notes. Much like the counterpart [SQLAlchemy docs](http://docs.sqlalchemy.org/en/latest/core/engines.html#sqlite)

