### PR TITLE
warning about naming your table User

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -19,7 +19,9 @@ then create the :class:`SQLAlchemy` object by passing it the application.
 Once created, that object then contains all the functions and helpers
 from both :mod:`sqlalchemy` and :mod:`sqlalchemy.orm`.  Furthermore it
 provides a class called ``Model`` that is a declarative base which can be
-used to declare models::
+used to declare models. Warning! Postgres has a reserved table called user.
+To avoid accidentally retrieving that table, make sure any sql queries
+use quotes (i.e. SELECT * FROM "USER")::
 
     from flask import Flask
     from flask_sqlalchemy import SQLAlchemy


### PR DESCRIPTION
Put in a warning to remind inexperienced users that using the table name User can cause confusion, as this table name is reserved in several databases (notably, Postgres). Although these docs use sqlite3, new users may be plugging in different databases and should not be worried with the table name. Ideally, the table/class name in docs should be unanimously changed to Users.