### PR TITLE
Fixed an error:

### DIFF
--- a/flask_sqlalchemy/__init__.py
+++ b/flask_sqlalchemy/__init__.py
@@ -745,7 +745,7 @@ class SQLAlchemy(object):
         self.session = self.create_scoped_session(session_options)
         self.Model = self.make_declarative_base(model_class, metadata)
         self._engine_lock = Lock()
-        self.app = app
+        self.app = None
         _include_sqlalchemy(self, query_class)
 
         if app is not None:
@@ -814,6 +814,8 @@ class SQLAlchemy(object):
         of an application not initialized that way or connections will
         leak.
         """
+        self.app = app
+
         if 'SQLALCHEMY_DATABASE_URI' not in app.config:
             warnings.warn(
                 'SQLALCHEMY_DATABASE_URI not set. Defaulting to '


### PR DESCRIPTION
    code and appearance:

        db = SQLAlchemy()
        # Now db.app is None

        # at __init__ in class SQLAlchemy(),  self.app = None
        db.init_app(app)

        # when exe at:
        #     app = self.get_app(app) in _execute_for_all_tables()
        #     self.app is still None
        #     so mistakenly raise a raise RuntimeError(
        #                                                  'application not registered on db instance and no application'
        #                                                  'bound to current context')
        db.create_all()