### PR TITLE
add one_or_404 method to BaseQuery

### DIFF
--- a/flask_sqlalchemy/__init__.py
+++ b/flask_sqlalchemy/__init__.py
@@ -426,6 +426,14 @@ class BaseQuery(orm.Query):
         if rv is None:
             abort(404)
         return rv
+    
+    def one_or_404(self):
+        """Like :meth:`one_or_none` but aborts with 404 if not found instead of returning ``None``."""
+
+        rv = self.one_or_none()
+        if rv is None:
+            abort(404)
+        return rv
 
     def paginate(self, page=None, per_page=None, error_out=True):
         """Returns ``per_page`` items from page ``page``.


### PR DESCRIPTION
This adds `one_or_404()` helper method in BaseQuery, based on SQLAlchemy `one_or_none()`.
This complements the existing `first_or_404()` and `get_or_404()` based on `get()` and `first()`.