### PR TITLE
rewrite tablename generation again

### DIFF
--- a/tests/test_table_name.py
+++ b/tests/test_table_name.py
@@ -1,3 +1,5 @@
+import inspect
+
 from sqlalchemy.ext.declarative import declared_attr
 
 
@@ -25,6 +27,7 @@ def test_single_name(db):
     class Mallard(Duck):
         pass
 
+    assert '__tablename__' not in Mallard.__dict__
     assert Mallard.__tablename__ == 'duck'
 
 
@@ -39,8 +42,10 @@ def test_joined_name(db):
     assert Donald.__tablename__ == 'donald'
 
 
-def test_mixin_name(db):
-    """Primary key provided by mixin should still allow model to set tablename."""
+def test_mixin_id(db):
+    """Primary key provided by mixin should still allow model to set
+    tablename.
+    """
     class Base(object):
         id = db.Column(db.Integer, primary_key=True)
 
@@ -51,8 +56,33 @@ def test_mixin_name(db):
     assert Duck.__tablename__ == 'duck'
 
 
+def test_mixin_attr(db):
+    """A declared attr tablename will be used down multiple levels of
+    inheritance.
+    """
+    class Mixin(object):
+        @declared_attr
+        def __tablename__(cls):
+            return cls.__name__.upper()
+
+    class Bird(Mixin, db.Model):
+        id = db.Column(db.Integer, primary_key=True)
+
+    class Duck(Bird):
+        # object reference
+        id = db.Column(db.ForeignKey(Bird.id), primary_key=True)
+
+    class Mallard(Duck):
+        # string reference
+        id = db.Column(db.ForeignKey('DUCK.id'), primary_key=True)
+
+    assert Bird.__tablename__ == 'BIRD'
+    assert Duck.__tablename__ == 'DUCK'
+    assert Mallard.__tablename__ == 'MALLARD'
+
+
 def test_abstract_name(db):
-    """Abstract model should not set a name.  Subclass should set a name."""
+    """Abstract model should not set a name. Subclass should set a name."""
     class Base(db.Model):
         __abstract__ = True
         id = db.Column(db.Integer, primary_key=True)
@@ -60,19 +90,23 @@ def test_abstract_name(db):
     class Duck(Base):
         pass
 
-    assert Base.__tablename__ == 'base'
+    assert '__tablename__' not in Base.__dict__
     assert Duck.__tablename__ == 'duck'
 
 
 def test_complex_inheritance(db):
-    """Joined table inheritance, but the new primary key is provided by a mixin, not directly on the class."""
+    """Joined table inheritance, but the new primary key is provided by a
+    mixin, not directly on the class.
+    """
     class Duck(db.Model):
         id = db.Column(db.Integer, primary_key=True)
 
     class IdMixin(object):
         @declared_attr
         def id(cls):
-            return db.Column(db.Integer, db.ForeignKey(Duck.id), primary_key=True)
+            return db.Column(
+                db.Integer, db.ForeignKey(Duck.id), primary_key=True
+            )
 
     class RubberDuck(IdMixin, Duck):
         pass
@@ -81,18 +115,55 @@ def test_complex_inheritance(db):
 
 
 def test_manual_name(db):
+    """Setting a manual name prevents generation for the immediate model. A
+    name is generated for joined but not single-table inheritance.
+    """
     class Duck(db.Model):
         __tablename__ = 'DUCK'
         id = db.Column(db.Integer, primary_key=True)
+        type = db.Column(db.String)
+
+        __mapper_args__ = {
+            'polymorphic_on': type
+        }
 
     class Daffy(Duck):
         id = db.Column(db.Integer, db.ForeignKey(Duck.id), primary_key=True)
 
+        __mapper_args__ = {
+            'polymorphic_identity': 'Warner'
+        }
+
+    class Donald(Duck):
+        __mapper_args__ = {
+            'polymorphic_identity': 'Disney'
+        }
+
     assert Duck.__tablename__ == 'DUCK'
     assert Daffy.__tablename__ == 'daffy'
+    assert '__tablename__' not in Donald.__dict__
+    assert Donald.__tablename__ == 'DUCK'
+    # polymorphic condition for single-table query
+    assert 'WHERE "DUCK".type' in str(Donald.query)
+
+
+def test_primary_constraint(db):
+    """Primary key will be picked up from table args."""
+    class Duck(db.Model):
+        id = db.Column(db.Integer)
+
+        __table_args__ = (
+            db.PrimaryKeyConstraint(id),
+        )
+
+    assert Duck.__table__ is not None
+    assert Duck.__tablename__ == 'duck'
 
 
 def test_no_access_to_class_property(db):
+    """Ensure the implementation doesn't access class properties or declared
+    attrs while inspecting the unmapped model.
+    """
     class class_property(object):
         def __init__(self, f):
             self.f = f
@@ -106,14 +177,13 @@ def test_no_access_to_class_property(db):
     class ns(object):
         accessed = False
 
-    # Since there's no id provided by the following model,
-    # _should_set_tablename will scan all attributes. If it's working
-    # properly, it won't access the class property, but will access the
-    # declared_attr.
-
     class Witch(Duck):
         @declared_attr
         def is_duck(self):
+            # declared attrs will be accessed during mapper configuration,
+            # but make sure they're not accessed before that
+            info = inspect.getouterframes(inspect.currentframe())[2]
+            assert info[3] != '_should_set_tablename'
             ns.accessed = True
 
         @class_property


### PR DESCRIPTION
A tablename will be set for non-abstract classes unless a mixin defines one or a model or mixin defines a `declared_attr`.

`__table_cls__` executes at a time when all column and primary key constraints are known, and can decide not to set a table when the model looks like single-table inheritance. It will also unset a tablename in this case.

I haven't added tests for the issues yet, but this should eventually fix #470, fix #473, fix #478, fix #481, fix #492, fix #512, fix #533. 😣

CC @zzzeek, @ThiefMaster 

---

Previously:

~Goes back to performing all tablename behavior in `_BoundDeclarativeMeta`, instead of putting some in a `declared_attr`. It would be more accurate to diff this against 2.1.~

~If you define a primary key in a `declared_attr`, you have to mark that attr as a the primary key, as we no longer evaluate those attrs against base classes.~

~Detects primary key constraint in `__table_args__`.~