### PR TITLE
limited per_page param in paginate

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -12,7 +12,10 @@ In development
   by models. (`#551`_)
 - Raise the correct error when a model has a table name but no primary key.
   (`#556`_)
+- Allow specifying a ``max_per_page`` limit for pagination, to avoid users
+  specifying high values in the request args. (`#542`_)
 
+.. _#542: https://github.com/mitsuhiko/flask-sqlalchemy/pull/542
 .. _#551: https://github.com/mitsuhiko/flask-sqlalchemy/pull/551
 .. _#556: https://github.com/mitsuhiko/flask-sqlalchemy/pull/556
 

--- a/flask_sqlalchemy/__init__.py
+++ b/flask_sqlalchemy/__init__.py
@@ -462,15 +462,15 @@ class BaseQuery(orm.Query):
                         abort(404)
 
                     per_page = 20
-                else:
-                    if max_per_page is not None:
-                        per_page = min(per_page, max_per_page)
         else:
             if page is None:
                 page = 1
 
             if per_page is None:
                 per_page = 20
+
+        if max_per_page is not None:
+            per_page = min(per_page, max_per_page)
 
         if error_out and page < 1:
             abort(404)

--- a/flask_sqlalchemy/__init__.py
+++ b/flask_sqlalchemy/__init__.py
@@ -427,7 +427,7 @@ class BaseQuery(orm.Query):
             abort(404)
         return rv
 
-    def paginate(self, page=None, per_page=None, error_out=True):
+    def paginate(self, page=None, per_page=None, error_out=True, max_per_page=None):
         """Returns ``per_page`` items from page ``page``.
 
         If no items are found and ``page`` is greater than 1, or if page is
@@ -462,6 +462,9 @@ class BaseQuery(orm.Query):
                         abort(404)
 
                     per_page = 20
+                else:
+                    if max_per_page is not None:
+                        per_page = min(per_page, max_per_page)
         else:
             if page is None:
                 page = 1

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -45,14 +45,7 @@ def test_query_paginate(app, db, Todo):
 
 def test_query_paginate_more_than_20(app, db, Todo):
     with app.app_context():
-        db.session.add_all([Todo('', '') for _ in range(100)])
+        db.session.add_all(Todo('', '') for _ in range(20))
         db.session.commit()
 
-    @app.route('/')
-    def index():
-        p = Todo.query.paginate(max_per_page=20)
-        return '{0} items retrieved'.format(len(p.items))
-
-    c = app.test_client()
-    r = c.get('/?per_page=500')
-    assert r.data.decode('utf8') == '20 items retrieved'
+    assert len(Todo.query.paginate(max_per_page=10).items) == 10

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -41,3 +41,18 @@ def test_query_paginate(app, db, Todo):
         # query default
         p = Todo.query.paginate()
         assert p.total == 100
+
+
+def test_query_paginate_more_than_20(app, db, Todo):
+    with app.app_context():
+        db.session.add_all([Todo('', '') for _ in range(100)])
+        db.session.commit()
+
+    @app.route('/')
+    def index():
+        p = Todo.query.paginate(max_per_page=20)
+        return '{0} items retrieved'.format(len(p.items))
+
+    c = app.test_client()
+    r = c.get('/?per_page=500')
+    assert r.data.decode('utf8') == '20 items retrieved'


### PR DESCRIPTION
Hey, in my application i used BaseQuery.paginate() method without any params and found that user can be able to use unlimited value for per_page param in http query. I think this param should be limited, here is the PR. 