### PR TITLE
update testing matrix, add coverage report

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,5 @@
+comment: off
+coverage:
+  status:
+    project: off
+    patch: off

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,11 @@
+[run]
+branch = True
+source =
+    flask_sqlalchemy
+    tests
+
+[paths]
+source =
+    flask_sqlalchemy
+    .tox/*/lib/python*/site-packages/flask_sqlalchemy
+    .tox/pypy/site-packages/flask_sqlalchemy

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ docs/_build
 *.egg
 .idea/
 .cache/
+htmlcov
+.coverage
+.coverage.*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,40 @@
 sudo: false
 language: python
 
-python:
-  - "2.6"
-  - "2.7"
-  - "pypy"
-  - "3.3"
-  - "3.4"
-  - "3.5"
-  - "3.6-dev"
-
-env:
-  - REQUIREMENTS=lowest
-  - REQUIREMENTS=current
+matrix:
+  include:
+    - python: 3.6
+      env: TOXENV=py,codecov
+    - python: 3.5
+      env: TOXENV=py,codecov
+    - python: 3.4
+      env: TOXENV=py,codecov
+    - python: 3.3
+      env: TOXENV=py,py-lowest,codecov
+    - python: 2.7
+      env: TOXENV=py,py,codecov
+    - python: 2.6
+      env: TOXENV=py,py-lowest,codecov
+    - python: pypy
+      env: TOXENV=py,codecov
+    - python: nightly
+      env: TOXENV=py,codecov
+    - python: 3.6
+      env: TOXENV=docs_html
 
 install:
   - pip install tox
 
 script:
-  - tox -e py-$REQUIREMENTS
+  - tox
+
+cache:
+  - pip
+
+branches:
+  only:
+    - master
+    - /^.*-maintenance$/
 
 notifications:
   email: false

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,8 @@ tag_date = 1
 release = egg_info -Db ''
 
 [tool:pytest]
-norecursedirs = .* _* scripts {args}
+minversion = 3.0
+testpaths = tests
 
 [bdist_wheel]
 universal = 1

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,45 @@
 [tox]
-envlist = {py26,py27,pypy,py33,py34,py35,py36}-{lowest,current}
+envlist =
+    py{36,35,34,33,27,26,py}
+    py{36,33,27,26,py}-lowest
+    docs_html
+    coverage_report
 
 [testenv]
-commands = py.test {posargs}
-
 deps =
-    pytest
+    pytest>=3
+    coverage
+    blinker
 
     lowest: flask==0.10
     lowest: sqlalchemy==0.8
-    lowest: blinker==1.0
 
-    current: flask
-    current: sqlalchemy
-    current: blinker
+commands =
+    coverage run -p -m pytest
+
+[testenv:docs_html]
+deps = sphinx
+commands = sphinx-build -W -b html -d {envtmpdir}/doctrees docs docs/_build/html
+
+[testenv:docs_linkcheck]
+deps = sphinx
+commands = sphinx-build -W -b linkcheck -d {envtmpdir}/doctrees docs docs/_build/linkcheck
+
+[testenv:coverage_report]
+deps = coverage
+skip_install = true
+commands =
+    coverage combine
+    coverage report
+    coverage html
+
+[testenv:codecov]
+passenv = CI TRAVIS TRAVIS_*
+deps =
+    codecov
+skip_install = true
+commands =
+    python -c 'import sys, pip; sys.version_info < (2, 7) and pip.main(["install", "argparse", "-q"])'
+    coverage combine
+    coverage report
+    codecov


### PR DESCRIPTION
Based on Flask's configuration. Travis uses 3.6 and nightly instead of 3.6-dev. Travis reports to codecov. Tox adds docs and coverage report. Coverage uses branch coverage.