### PR TITLE
pass real app instead of current_app to connector

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 Changelog
 =========
 
+
 Version 2.3.0
 -------------
 
@@ -23,10 +24,15 @@ In development
   removed in 3.0. (`#546`_)
 - Models have a default ``repr`` that shows the model name and primary key.
   (`#530`_)
+- Fixed a bug where using ``init_app`` would cause connectors to always use the
+  ``current_app`` rather than the app they were created for. This caused issues
+  when multiple apps were registered with the extension. (`#547`_)
 
 .. _#530: https://github.com/mitsuhiko/flask-sqlalchemy/pull/530
 .. _#541: https://github.com/mitsuhiko/flask-sqlalchemy/pull/541
 .. _#546: https://github.com/mitsuhiko/flask-sqlalchemy/pull/546
+.. _#547: https://github.com/mitsuhiko/flask-sqlalchemy/pull/547
+
 
 Version 2.2
 -----------

--- a/flask_sqlalchemy/__init__.py
+++ b/flask_sqlalchemy/__init__.py
@@ -887,14 +887,14 @@ class SQLAlchemy(object):
             return reference_app
 
         if current_app:
-            return current_app
+            return current_app._get_current_object()
 
         if self.app is not None:
             return self.app
 
         raise RuntimeError(
-            'application not registered on db instance and no application'
-            'bound to current context'
+            'No application found. Either work inside a view function or push'
+            ' an application context.'
         )
 
     def get_tables_for_bind(self, bind=None):

--- a/tests/test_binds.py
+++ b/tests/test_binds.py
@@ -1,3 +1,5 @@
+import flask_sqlalchemy as fsa
+
 
 def test_basic_binds(app, db):
     app.config['SQLALCHEMY_BINDS'] = {
@@ -78,3 +80,14 @@ def test_abstract_binds(app, db):
     metadata.reflect(bind=db.get_engine(app, 'foo'))
     assert len(metadata.tables) == 1
     assert 'foo_bound_model' in metadata.tables
+
+
+def test_connector_cache(app):
+    db = fsa.SQLAlchemy()
+    db.init_app(app)
+
+    with app.app_context():
+        db.get_engine()
+
+    connector = fsa.get_state(app).connectors[None]
+    assert connector._app is app


### PR DESCRIPTION
fixes #490 

If `init_app` was used and there were multiple apps registered, each connector and engine would use `current_app` instead of the actual app they were created for. Call `current_app._get_current_object()` to fix this.