### PR TITLE
model uses existing table by name

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,18 @@ Changelog
 =========
 
 
+Version 2.3.1
+-------------
+
+In development
+
+- If a model has a table name that matches an existing table in the metadata,
+  use that table. Fixes a regression where reflected tables were not picked up
+  by models. (`#551`_)
+
+.. _#551: https://github.com/mitsuhiko/flask-sqlalchemy/pull/551
+
+
 Version 2.3.0
 -------------
 

--- a/flask_sqlalchemy/model.py
+++ b/flask_sqlalchemy/model.py
@@ -3,6 +3,7 @@ import re
 import sqlalchemy as sa
 from sqlalchemy import inspect
 from sqlalchemy.ext.declarative import DeclarativeMeta, declared_attr
+from sqlalchemy.schema import _get_table_key
 
 from ._compat import to_str
 
@@ -72,6 +73,11 @@ class NameMetaMixin(object):
         If no primary key is found, that indicates single-table inheritance,
         so no table will be created and ``__tablename__`` will be unset.
         """
+        key = _get_table_key(args[0], kwargs.get('schema'))
+
+        if key in cls.metadata.tables:
+            return sa.Table(*args, **kwargs)
+
         for arg in args:
             if (
                 (isinstance(arg, sa.Column) and arg.primary_key)

--- a/tests/test_table_name.py
+++ b/tests/test_table_name.py
@@ -191,3 +191,15 @@ def test_no_access_to_class_property(db):
             assert False
 
     assert ns.accessed
+
+
+def test_metadata_has_table(db):
+    user = db.Table(
+        'user',
+        db.Column('id', db.Integer, primary_key=True),
+    )
+
+    class User(db.Model):
+        pass
+
+    assert User.__table__ is user


### PR DESCRIPTION
If tables are already defined (or reflected), creating a model with an existing table name uses (or extends) that table. This worked in plain SQLAlchemy and 2.1, 2.2. `__table_cls__` needed to check for this.

fixes #550