### PR TITLE
raise correct error when model has name but no pkey

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -10,8 +10,11 @@ In development
 - If a model has a table name that matches an existing table in the metadata,
   use that table. Fixes a regression where reflected tables were not picked up
   by models. (`#551`_)
+- Raise the correct error when a model has a table name but no primary key.
+  (`#556`_)
 
 .. _#551: https://github.com/mitsuhiko/flask-sqlalchemy/pull/551
+.. _#556: https://github.com/mitsuhiko/flask-sqlalchemy/pull/556
 
 
 Version 2.3.0

--- a/flask_sqlalchemy/model.py
+++ b/flask_sqlalchemy/model.py
@@ -73,11 +73,15 @@ class NameMetaMixin(object):
         If no primary key is found, that indicates single-table inheritance,
         so no table will be created and ``__tablename__`` will be unset.
         """
+        # check if a table with this name already exists
+        # allows reflected tables to be applied to model by name
         key = _get_table_key(args[0], kwargs.get('schema'))
 
         if key in cls.metadata.tables:
             return sa.Table(*args, **kwargs)
 
+        # if a primary key or constraint is found, create a table for
+        # joined-table inheritance
         for arg in args:
             if (
                 (isinstance(arg, sa.Column) and arg.primary_key)
@@ -85,6 +89,15 @@ class NameMetaMixin(object):
             ):
                 return sa.Table(*args, **kwargs)
 
+        # if no base classes define a table, return one
+        # ensures the correct error shows up when missing a primary key
+        for base in cls.__mro__[1:-1]:
+            if '__table__' in base.__dict__:
+                break
+        else:
+            return sa.Table(*args, **kwargs)
+
+        # single-table inheritance, use the parent tablename
         if '__tablename__' in cls.__dict__:
             del cls.__tablename__
 

--- a/tests/test_table_name.py
+++ b/tests/test_table_name.py
@@ -1,5 +1,7 @@
 import inspect
 
+import pytest
+from sqlalchemy.exc import ArgumentError
 from sqlalchemy.ext.declarative import declared_attr
 
 
@@ -203,3 +205,11 @@ def test_metadata_has_table(db):
         pass
 
     assert User.__table__ is user
+
+
+def test_correct_error_for_no_primary_key(db):
+    with pytest.raises(ArgumentError) as info:
+        class User(db.Model):
+            pass
+
+    assert 'could not assemble any primary key' in str(info.value)


### PR DESCRIPTION
fixes #552 

```python
class User(db.Model):
    name = db.Column(db.String)
```

```
sqlalchemy.exc.ArgumentError: Mapper Mapper|User|user could not assemble any primary key columns for mapped table 'user'
```