### PR TITLE
don't mask parent table on single-table inheritance

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,16 @@ Changelog
 =========
 
 
+Version 2.3.2
+-------------
+
+Released on October 11, 2017
+
+- Don't mask the parent table for single-table inheritance models. (`#561`_)
+
+.. _#561: https://github.com/mitsuhiko/flask-sqlalchemy/pull/561
+
+
 Version 2.3.1
 -------------
 

--- a/flask_sqlalchemy/__init__.py
+++ b/flask_sqlalchemy/__init__.py
@@ -32,7 +32,7 @@ from flask_sqlalchemy.model import Model
 from ._compat import itervalues, string_types, to_str, xrange
 from .model import DefaultMeta
 
-__version__ = '2.3.1'
+__version__ = '2.3.2'
 
 # the best timer function for the platform
 if sys.platform == 'win32':

--- a/flask_sqlalchemy/model.py
+++ b/flask_sqlalchemy/model.py
@@ -66,6 +66,15 @@ class NameMetaMixin(object):
 
         super(NameMetaMixin, cls).__init__(name, bases, d)
 
+        # __table_cls__ has run at this point
+        # if no table was created, use the parent table
+        if (
+            '__tablename__' not in cls.__dict__
+            and '__table__' in cls.__dict__
+            and cls.__dict__['__table__'] is None
+        ):
+            del cls.__table__
+
     def __table_cls__(cls, *args, **kwargs):
         """This is called by SQLAlchemy during mapper setup. It determines the
         final table object that the model will use.

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ from setuptools import setup
 
 setup(
     name='Flask-SQLAlchemy',
-    version='2.3.1',
+    version='2.3.2',
     url='http://github.com/mitsuhiko/flask-sqlalchemy',
     license='BSD',
     author='Armin Ronacher',

--- a/tests/test_table_name.py
+++ b/tests/test_table_name.py
@@ -213,3 +213,14 @@ def test_correct_error_for_no_primary_key(db):
             pass
 
     assert 'could not assemble any primary key' in str(info.value)
+
+
+def test_single_has_parent_table(db):
+    class Duck(db.Model):
+        id = db.Column(db.Integer, primary_key=True)
+
+    class Call(Duck):
+        pass
+
+    assert Call.__table__ is Duck.__table__
+    assert '__table__' not in Call.__dict__


### PR DESCRIPTION
SQLAlchemy unconditionally sets `__table__` to the result of `__table_cls__`. In single-table inheritance, Flask-SQLAlchemy returns `None`, but in plain SQLAlchemy `__table__` is not even set.

fixes #560