### PR TITLE
Add SQLALCHEMY_POOL_PRE_PING config

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -51,6 +51,15 @@ A list of configuration keys currently understood by the extension:
                                    different default timeout value. For more
                                    information about timeouts see
                                    :ref:`timeouts`.
+``SQLALCHEMY_POOL_PRE_PING``       Native "pessimistic disconnection" handling
+                                   to the Pool object.  This emits a simple
+                                   statement, typically "SELECT 1",
+                                   to test the connection for liveness.
+                                   If the existing connection is no longer able
+                                   to respond to commands, the connection is
+                                   transparently recycled, and all other
+                                   connections made prior to the current
+                                   timestamp are invalidated.
 ``SQLALCHEMY_MAX_OVERFLOW``        Controls the number of connections that
                                    can be created after the pool reached
                                    its maximum size.  When those additional

--- a/flask_sqlalchemy/__init__.py
+++ b/flask_sqlalchemy/__init__.py
@@ -783,6 +783,7 @@ class SQLAlchemy(object):
         app.config.setdefault('SQLALCHEMY_POOL_SIZE', None)
         app.config.setdefault('SQLALCHEMY_POOL_TIMEOUT', None)
         app.config.setdefault('SQLALCHEMY_POOL_RECYCLE', None)
+        app.config.setdefault('SQLALCHEMY_POOL_PRE_PING', False)
         app.config.setdefault('SQLALCHEMY_MAX_OVERFLOW', None)
         app.config.setdefault('SQLALCHEMY_COMMIT_ON_TEARDOWN', False)
         track_modifications = app.config.setdefault(
@@ -815,6 +816,7 @@ class SQLAlchemy(object):
         _setdefault('pool_size', 'SQLALCHEMY_POOL_SIZE')
         _setdefault('pool_timeout', 'SQLALCHEMY_POOL_TIMEOUT')
         _setdefault('pool_recycle', 'SQLALCHEMY_POOL_RECYCLE')
+        _setdefault('pool_pre_ping', 'SQLALCHEMY_POOL_PRE_PING')
         _setdefault('max_overflow', 'SQLALCHEMY_MAX_OVERFLOW')
 
     def apply_driver_hacks(self, app, info, options):

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     platforms='any',
     install_requires=[
         'Flask>=0.10',
-        'SQLAlchemy>=0.8.0'
+        'SQLAlchemy>=1.2.0'
     ],
     test_suite='test_sqlalchemy.suite',
     classifiers=[


### PR DESCRIPTION
Add `SQLALCHEMY_POOL_PRE_PING` config to test pool connection for liveness, which is added in SQLAlchemy 1.2.0.