### PR TITLE
Drop support for EOL Python 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,6 @@ matrix:
       env: TOXENV=py,py-lowest,codecov
     - python: 2.7
       env: TOXENV=py,codecov
-    - python: 2.6
-      env: TOXENV=py,py-lowest,codecov
     - python: pypy
       env: TOXENV=py,codecov
     - python: nightly

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,7 +45,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Flask-SQLAlchemy'
-copyright = u'2010 - {0}, Armin Ronacher'.format(datetime.utcnow().year)
+copyright = u'2010 - {}, Armin Ronacher'.format(datetime.utcnow().year)
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/examples/hello.py
+++ b/examples/hello.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from flask import Flask, request, flash, url_for, redirect, \
-     render_template, abort
+     render_template
 from flask_sqlalchemy import SQLAlchemy
 
 

--- a/flask_sqlalchemy/__init__.py
+++ b/flask_sqlalchemy/__init__.py
@@ -29,7 +29,7 @@ from sqlalchemy.orm.exc import UnmappedClassError
 from sqlalchemy.orm.session import Session as SessionBase
 
 from flask_sqlalchemy.model import Model
-from ._compat import itervalues, string_types, to_str, xrange
+from ._compat import itervalues, string_types, xrange
 from .model import DefaultMeta
 
 __version__ = '2.3.2'

--- a/flask_sqlalchemy/model.py
+++ b/flask_sqlalchemy/model.py
@@ -148,7 +148,7 @@ class Model(object):
     def __repr__(self):
         identity = inspect(self).identity
         if identity is None:
-            pk = "(transient {0})".format(id(self))
+            pk = "(transient {})".format(id(self))
         else:
             pk = ', '.join(to_str(value) for value in identity)
-        return '<{0} {1}>'.format(type(self).__name__, pk)
+        return '<{} {}>'.format(type(self).__name__, pk)

--- a/scripts/make-release.py
+++ b/scripts/make-release.py
@@ -26,7 +26,6 @@ def parse_changelog():
             match = re.search('^Version\s+(.*)', line.strip())
             if match is None:
                 continue
-            length = len(match.group(1))
             version = match.group(1).strip()
             if lineiter.next().count('-') != len(match.group(0)):
                 continue

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,6 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -30,7 +30,7 @@ def test_query_paginate(app, db, Todo):
     @app.route('/')
     def index():
         p = Todo.query.paginate()
-        return '{0} items retrieved'.format(len(p.items))
+        return '{} items retrieved'.format(len(p.items))
 
     c = app.test_client()
     # request default

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    py{36,35,34,33,27,26,py}
-    py{36,33,27,26,py}-lowest
+    py{36,35,34,33,27,py}
+    py{36,33,27,py}-lowest
     docs_html
     coverage_report
 
@@ -39,7 +39,6 @@ deps =
     codecov
 skip_install = true
 commands =
-    python -c 'import sys, pip; sys.version_info < (2, 7) and pip.main(["install", "argparse", "-q"])'
     coverage combine
     coverage report
     codecov


### PR DESCRIPTION
Fixes #587.

Travis CI is failing because SQLAlchemy no longer supports Python 2.6, as it's been EOL for over four years:
```
Collecting SQLAlchemy>=0.8.0 (from Flask-SQLAlchemy==2.3.2.dev20180120) 
Downloading SQLAlchemy-1.2.1.tar.gz (5.5MB)
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-cHubfe/SQLAlchemy/setup.py", line 16, in <module>
        raise Exception("SQLAlchemy requires Python 2.7 or higher.")
    Exception: SQLAlchemy requires Python 2.7 or higher.
```
For example: PR https://github.com/mitsuhiko/flask-sqlalchemy/issues/587.

Re: http://docs.sqlalchemy.org/en/latest/changelog/migration_12.html#targeting-python-2-7-and-up 
and: https://github.com/zzzeek/sqlalchemy/commit/1da9d3752160430c91534a8868ceb8c5ad1451d4

Here's the pip installs for Flask-SQLAlchemy from PyPI for last month:

| python_version | percent | download_count |
| -------------- | ------: | -------------: |
| 2.7            |   85.8% |        645,538 |
| 3.6            |    7.7% |         57,602 |
| 3.5            |    3.8% |         28,411 |
| 3.4            |    2.5% |         18,775 |
| 2.6            |    0.1% |            868 |
| 3.7            |    0.1% |            532 |
| 3.3            |    0.0% |            346 |
| None           |    0.0% |              4 |
| 3.2            |    0.0% |              1 |

Source: `pypinfo --start-date -51 --end-date -21 --percent --pip --markdown Flask-SQLAlchemy pyversion`

Python 3.3 is also EOL and even less used, but not causing any problems yet. Should that be dropped too?
