### PR TITLE
Python 3 tweaks in docs

### DIFF
--- a/docs/queries.rst
+++ b/docs/queries.rst
@@ -82,7 +82,7 @@ Retrieve a user by username:
 >>> peter.id
 2
 >>> peter.email
-u'peter@example.org'
+'peter@example.org'
 
 Same as above but for a non existing username gives `None`:
 
@@ -93,22 +93,22 @@ True
 Selecting a bunch of users by a more complex expression:
 
 >>> User.query.filter(User.email.endswith('@example.com')).all()
-[<User u'admin'>, <User u'guest'>]
+[<User 'admin'>, <User 'guest'>]
 
 Ordering users by something:
 
 >>> User.query.order_by(User.username).all()
-[<User u'admin'>, <User u'guest'>, <User u'peter'>]
+[<User 'admin'>, <User 'guest'>, <User 'peter'>]
 
 Limiting users:
 
 >>> User.query.limit(1).all()
-[<User u'admin'>]
+[<User 'admin'>]
 
 Getting user by primary key:
 
 >>> User.query.get(1)
-<User u'admin'>
+<User 'admin'>
 
 
 Queries in Views

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -60,9 +60,9 @@ But they are not yet in the database, so let's make sure they are::
 Accessing the data in database is easy as a pie::
 
     >>> User.query.all()
-    [<User u'admin'>, <User u'guest'>]
+    [<User 'admin'>, <User 'guest'>]
     >>> User.query.filter_by(username='admin').first()
-    <User u'admin'>
+    <User 'admin'>
 
 Note how we never defined a ``__init__`` method on the ``User`` class?
 That's because SQLAlchemy adds an implicit constructor to all model
@@ -143,8 +143,8 @@ load all categories and their posts, you could do it like this::
     >>> from sqlalchemy.orm import joinedload
     >>> query = Category.query.options(joinedload('posts'))
     >>> for category in query:
-    ...     print category, category.posts
-    <Category u'Python'> [<Post u'Hello Python!'>, <Post u'Snakes'>]
+    ...     print(category, category.posts)
+    <Category 'Python'> [<Post 'Hello Python!'>, <Post 'Snakes'>]
 
 
 If you want to get a query object for that relationship, you can do so


### PR DESCRIPTION
This is a couple of cases of repr() producing u-prefixes on strings and one instance of the print statement.

Seems fairly safe to assume that new users won't be on legacy Python so this updates the docs to be in line with what they'll see :)