### PR TITLE
Add `engine_params` parameter to `flask_sqlalchemy.SQLAlchemy` constructor

### DIFF
--- a/tests/test_custom_engine_params.py
+++ b/tests/test_custom_engine_params.py
@@ -1,0 +1,25 @@
+import pytest
+import flask_sqlalchemy as fsa
+
+
+def test_set_engine_params(app):
+    db = fsa.SQLAlchemy(app, engine_params={'pool_pre_ping': True})
+    options = dict()
+    db.apply_engine_params(app, options)
+
+    assert options['pool_pre_ping'] is True
+
+
+def test_set_engine_params_overrides_defaults(app):
+    db = fsa.SQLAlchemy(app, engine_params={'max_overflow': 20})
+    options = dict()
+    db.apply_engine_params(app, options)
+
+    assert options['max_overflow'] == 20
+
+
+def test_set_engine_params_wrong_param(app):
+    db = fsa.SQLAlchemy(app, engine_params={'wrong': 20})
+
+    with pytest.raises(TypeError):
+        db.engine


### PR DESCRIPTION
One of the most discussed topic of issues is to add some additional parameters for passing to `sqlalchemy.create_engine` function (http://docs.sqlalchemy.org/en/latest/core/engines.html#sqlalchemy.create_engine). `engine_params` dictionary is passed 'as is' to `sqlalchemy.create_engine`, so now it allows to pass such parameters as `isolation_level` (#120 ), `pool_pre_ping` (#577 )  etc.

Example of usage:

```python
from sqlalchemy.pool import StaticPool

db = SQLAlchemy(engine_params={'isolation_level': 'READ_UNCOMMITED', 'poolclass': StaticPool})
```