### PR TITLE
Drop support for EOL Python 2.6 and 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,6 @@ matrix:
       env: TOXENV=py,py-lowest,codecov
     - python: 2.7
       env: TOXENV=py,codecov
-    - python: 2.6
-      env: TOXENV=py,py-lowest,codecov
     - python: pypy
       env: TOXENV=py,codecov
     - python: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ matrix:
       env: TOXENV=py,codecov
     - python: 3.4
       env: TOXENV=py,codecov
-    - python: 3.3
-      env: TOXENV=py,py-lowest,codecov
     - python: 2.7
       env: TOXENV=py,codecov
     - python: pypy

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,7 +45,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Flask-SQLAlchemy'
-copyright = u'2010 - {0}, Armin Ronacher'.format(datetime.utcnow().year)
+copyright = u'2010 - {}, Armin Ronacher'.format(datetime.utcnow().year)
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/examples/hello.py
+++ b/examples/hello.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from flask import Flask, request, flash, url_for, redirect, \
-     render_template, abort
+     render_template
 from flask_sqlalchemy import SQLAlchemy
 
 

--- a/flask_sqlalchemy/__init__.py
+++ b/flask_sqlalchemy/__init__.py
@@ -29,7 +29,7 @@ from sqlalchemy.orm.exc import UnmappedClassError
 from sqlalchemy.orm.session import Session as SessionBase
 
 from flask_sqlalchemy.model import Model
-from ._compat import itervalues, string_types, to_str, xrange
+from ._compat import itervalues, string_types, xrange
 from .model import DefaultMeta
 
 __version__ = '2.3.2'

--- a/flask_sqlalchemy/model.py
+++ b/flask_sqlalchemy/model.py
@@ -148,7 +148,7 @@ class Model(object):
     def __repr__(self):
         identity = inspect(self).identity
         if identity is None:
-            pk = "(transient {0})".format(id(self))
+            pk = "(transient {})".format(id(self))
         else:
             pk = ', '.join(to_str(value) for value in identity)
-        return '<{0} {1}>'.format(type(self).__name__, pk)
+        return '<{} {}>'.format(type(self).__name__, pk)

--- a/scripts/make-release.py
+++ b/scripts/make-release.py
@@ -26,7 +26,6 @@ def parse_changelog():
             match = re.search('^Version\s+(.*)', line.strip())
             if match is None:
                 continue
-            length = len(match.group(1))
             version = match.group(1).strip()
             if lineiter.next().count('-') != len(match.group(0)):
                 continue

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,6 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -30,7 +30,7 @@ def test_query_paginate(app, db, Todo):
     @app.route('/')
     def index():
         p = Todo.query.paginate()
-        return '{0} items retrieved'.format(len(p.items))
+        return '{} items retrieved'.format(len(p.items))
 
     c = app.test_client()
     # request default

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    py{36,35,34,33,27,26,py}
-    py{36,33,27,26,py}-lowest
+    py{36,35,34,33,27,py}
+    py{36,33,27,py}-lowest
     docs_html
     coverage_report
 
@@ -39,7 +39,6 @@ deps =
     codecov
 skip_install = true
 commands =
-    python -c 'import sys, pip; sys.version_info < (2, 7) and pip.main(["install", "argparse", "-q"])'
     coverage combine
     coverage report
     codecov

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    py{36,35,34,33,27,py}
-    py{36,33,27,py}-lowest
+    py{36,35,34,27,py}
+    py{36,34,27,py}-lowest
     docs_html
     coverage_report
 


### PR DESCRIPTION
This includes PR #588 ("Drop support for EOL Python 2.6") and therefore closes #588 and closes #587 and adds a single new commit to drop 3.3.

Python 3.3 is also EOL and used even less than 2.6.

Here's the pip installs for Flask-SQLAlchemy from PyPI for last month:

| python_version | percent | download_count |
| -------------- | ------: | -------------: |
| 2.7            |  83.31% |        468,134 |
| 3.6            |   9.90% |         55,611 |
| 3.5            |   4.43% |         24,867 |
| 3.4            |   2.20% |         12,369 |
| 2.6            |   0.07% |            420 |
| 3.7            |   0.06% |            342 |
| 3.3            |   0.03% |            186 |
| None           |   0.00% |              1 |

Source: `pypinfo --start-date -39 --end-date -12 --percent --pip --markdown Flask-SQLAlchemy pyversion`

These show the February 2018 download counts for 2.6 and 3.3 are around half what they were in December 2017 (see https://github.com/mitsuhiko/flask-sqlalchemy/pull/588).