### PR TITLE
fix typo in code example in the docs

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -73,7 +73,7 @@ constructor with those ``**kwargs`` to preserve this behavior::
 
     class Foo(db.Model):
         # ...
-        def __init__(**kwargs):
+        def __init__(self, **kwargs):
             super(Foo, self).__init__(**kwargs)
             # do custom stuff
 


### PR DESCRIPTION
added missing self argument to the __init__ def