### PR TITLE
Drop support for Python 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,6 @@ matrix:
       env: TOXENV=py,py-lowest,codecov
     - python: 2.7
       env: TOXENV=py,codecov
-    - python: 2.6
-      env: TOXENV=py,py-lowest,codecov
     - python: pypy
       env: TOXENV=py,codecov
     - python: nightly

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,6 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',


### PR DESCRIPTION
SQLAlchemy requires Python 2.7 or higher.