### PR TITLE
add SQLALCHEMY_POOL_PRE_PING

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -51,6 +51,8 @@ A list of configuration keys currently understood by the extension:
                                    different default timeout value. For more
                                    information about timeouts see
                                    :ref:`timeouts`.
+``SQLALCHEMY_POOL_PRE_PING``       Checks whether a connection is still viable
+                                   at pool checkout.
 ``SQLALCHEMY_MAX_OVERFLOW``        Controls the number of connections that
                                    can be created after the pool reached
                                    its maximum size.  When those additional
@@ -80,6 +82,8 @@ A list of configuration keys currently understood by the extension:
    The ``SQLALCHEMY_TRACK_MODIFICATIONS`` configuration key was added.
 .. versionchanged:: 2.1
    ``SQLALCHEMY_TRACK_MODIFICATIONS`` will warn if unset.
+.. versionadded:: 2.4
+   The ``SQLALCHEMY_POOL_PRE_PING`` configuration key was added.
 
 Connection URI Format
 ---------------------

--- a/flask_sqlalchemy/__init__.py
+++ b/flask_sqlalchemy/__init__.py
@@ -787,6 +787,7 @@ class SQLAlchemy(object):
         app.config.setdefault('SQLALCHEMY_POOL_SIZE', None)
         app.config.setdefault('SQLALCHEMY_POOL_TIMEOUT', None)
         app.config.setdefault('SQLALCHEMY_POOL_RECYCLE', None)
+        app.config.setdefault('SQLALCHEMY_POOL_PRE_PING', None)
         app.config.setdefault('SQLALCHEMY_MAX_OVERFLOW', None)
         app.config.setdefault('SQLALCHEMY_COMMIT_ON_TEARDOWN', False)
         track_modifications = app.config.setdefault(
@@ -819,6 +820,7 @@ class SQLAlchemy(object):
         _setdefault('pool_size', 'SQLALCHEMY_POOL_SIZE')
         _setdefault('pool_timeout', 'SQLALCHEMY_POOL_TIMEOUT')
         _setdefault('pool_recycle', 'SQLALCHEMY_POOL_RECYCLE')
+        _setdefault('pool_pre_ping', 'SQLALCHEMY_POOL_PRE_PING')
         _setdefault('max_overflow', 'SQLALCHEMY_MAX_OVERFLOW')
 
     def apply_driver_hacks(self, app, info, options):


### PR DESCRIPTION
This allows setting the create_engine() pool_pre_ping argument via flask configuration.

I've had some test failures locally but they appear to be unrelated as far as I can tell.