### PR TITLE
fix BindMetaMixin with polymorphic

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+Version 2.3.3
+-------------
+
+Fix "AttributeError: 'NoneType' object has no attribute 'info'", when using polymorphic models. (`#651`_)
+
+.. _#651: https://github.com/mitsuhiko/flask-sqlalchemy/pull/651
+
 
 Version 2.3.2
 -------------

--- a/flask_sqlalchemy/model.py
+++ b/flask_sqlalchemy/model.py
@@ -120,7 +120,7 @@ class BindMetaMixin(object):
 
         super(BindMetaMixin, cls).__init__(name, bases, d)
 
-        if bind_key is not None and hasattr(cls, '__table__'):
+        if bind_key is not None and getattr(cls, '__table__', None) is not None:
             cls.__table__.info['bind_key'] = bind_key
 
 


### PR DESCRIPTION
AttributeError: 'NoneType' object has no attribute 'info'
flask_sqlalchemy/model.py:124: AttributeError

How to reproduce:
   
   ```
bind_key = 'polymorphic_bind_key'

    app.config['SQLALCHEMY_BINDS'] = {
        bind_key: 'sqlite:///:memory',
    }

    class Base(db.Model):
        __bind_key__ = bind_key

        __tablename__ = 'base'

        id = db.Column(db.Integer, primary_key=True)

        p_type = db.Column(db.String(50))

        __mapper_args__ = {
            'polymorphic_identity': 'base',
            'polymorphic_on': p_type
        }

    class Child1(Base):

        child_1_data = db.Column(db.String(50))
        __mapper_args__ = {
            'polymorphic_identity': 'child_1',
        }
```