### PR TITLE
Add SQLALCHEMY_POOL_PRE_PING configuration option

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -51,6 +51,10 @@ A list of configuration keys currently understood by the extension:
                                    different default timeout value. For more
                                    information about timeouts see
                                    :ref:`timeouts`.
+``SQLALCHEMY_POOL_PRE_PING``       Test the connection is alive with a
+                                   dialect specific ping, typically
+                                   ``SELECT 1``. When not alive, the connection
+                                   will be transparently reconnected.
 ``SQLALCHEMY_MAX_OVERFLOW``        Controls the number of connections that
                                    can be created after the pool reached
                                    its maximum size.  When those additional

--- a/flask_sqlalchemy/__init__.py
+++ b/flask_sqlalchemy/__init__.py
@@ -788,6 +788,7 @@ class SQLAlchemy(object):
         app.config.setdefault('SQLALCHEMY_POOL_TIMEOUT', None)
         app.config.setdefault('SQLALCHEMY_POOL_RECYCLE', None)
         app.config.setdefault('SQLALCHEMY_MAX_OVERFLOW', None)
+        app.config.setdefault('SQLALCHEMY_POOL_PRE_PING', None)
         app.config.setdefault('SQLALCHEMY_COMMIT_ON_TEARDOWN', False)
         track_modifications = app.config.setdefault(
             'SQLALCHEMY_TRACK_MODIFICATIONS', None
@@ -820,6 +821,7 @@ class SQLAlchemy(object):
         _setdefault('pool_timeout', 'SQLALCHEMY_POOL_TIMEOUT')
         _setdefault('pool_recycle', 'SQLALCHEMY_POOL_RECYCLE')
         _setdefault('max_overflow', 'SQLALCHEMY_MAX_OVERFLOW')
+        _setdefault('pool_pre_ping', 'SQLALCHEMY_POOL_PRE_PING')
 
     def apply_driver_hacks(self, app, info, options):
         """This method is called before engine creation and used to inject


### PR DESCRIPTION
This allows configuring the value of the POOL_PRE_PING through a configuration variable.

- [Pool Pre Ping docs](https://docs.sqlalchemy.org/en/latest/core/pooling.html#sqlalchemy.pool.Pool.params.pre_ping)
- [`create_engine` docs](https://docs.sqlalchemy.org/en/latest/core/engines.html#sqlalchemy.create_engine.params.pool_pre_ping)